### PR TITLE
Feat/人口マップページのマークアップを実装

### DIFF
--- a/pages/population.tsx
+++ b/pages/population.tsx
@@ -1,0 +1,3 @@
+import PopulationPage from "@/components/population/Population";
+
+export default PopulationPage;

--- a/src/components/layouts/Layout.module.css
+++ b/src/components/layouts/Layout.module.css
@@ -1,9 +1,13 @@
-.main {
-  min-height: 100vh;
-  padding: 4rem 0;
-  flex: 1;
+.container {
   display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
+}
+
+.side {
+  width: 20%;
+}
+
+.main {
+  width: 80%;
+  min-height: 100vh;
+  padding: 4rem 2rem;
 }

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -8,9 +8,11 @@ interface Props {
 
 export const Layout = ({ children }: Props) => {
   return (
-    <React.Fragment>
-      <MenuBar />
+    <div className={style.container}>
+      <div className={style.side}>
+        <MenuBar />
+      </div>
       <div className={style.main}>{children}</div>
-    </React.Fragment>
+    </div>
   );
 };

--- a/src/components/population/Population.module.css
+++ b/src/components/population/Population.module.css
@@ -1,0 +1,55 @@
+
+.searchArea {
+  display: flex;
+  width: 100%;
+}
+
+.searchInputWrap {
+  width: 80%;
+  margin-right: auto;
+}
+
+.searchInput {
+  width: 100%;
+  height: 4.8rem;
+  border: 1px solid #eaeaea;
+  border-radius: 18px;
+  padding: 1rem;
+}
+
+.searchBtnWrap {
+  width: 15%;
+}
+
+.searchBtn {
+  width: 100%;
+  height: 4.8rem;
+  border: 1px solid #eaeaea;
+  border-radius: 18px;
+}
+
+.mainCategoryContentsArea {
+  margin: 2.4rem 0;
+}
+
+.mainCategoryTitle {
+  font-size: 2rem;
+}
+
+.subCategoryContentsArea {
+  display: flex;
+}
+
+.subCategoryContentWrap {
+  width: 50%;
+  height: 50rem;
+}
+
+.subCategoryTitle {
+  font-size: 1.6rem;
+}
+
+.subCategoryContent {
+  width: 100%;
+  height: 100%;
+}

--- a/src/components/population/Population.tsx
+++ b/src/components/population/Population.tsx
@@ -1,0 +1,14 @@
+import type { NextPage } from "next";
+import { Layout } from "@/components/layouts/Layout";
+
+const PopulationPage: NextPage = () => {
+  return (
+    <div>
+      <Layout>
+        <p>test</p>
+      </Layout>
+    </div>
+  );
+};
+
+export default PopulationPage;

--- a/src/components/population/Population.tsx
+++ b/src/components/population/Population.tsx
@@ -1,11 +1,46 @@
 import type { NextPage } from "next";
+import style from "./Population.module.css";
 import { Layout } from "@/components/layouts/Layout";
 
 const PopulationPage: NextPage = () => {
   return (
     <div>
       <Layout>
-        <p>test</p>
+        <div className={style.searchArea}>
+          <div className={style.searchInputWrap}>
+            <input
+              className={style.searchInput}
+              type="search"
+              name="search"
+              placeholder="検索"
+            />
+          </div>
+          <div className={style.searchBtnWrap}>
+            <input
+              className={style.searchBtn}
+              type="submit"
+              name="submit"
+              value="検索"
+            />
+          </div>
+        </div>
+        <div className={style.mainCategoryContentsArea}>
+          <h1 className={style.mainCategoryTitle}>人口構成</h1>
+          <div className={style.subCategoryContentsArea}>
+            <div className={style.subCategoryContentWrap}>
+              <h2 className={style.subCategoryTitle}>人口構成</h2>
+              <div className={style.subCategoryContent}>
+                <p>人口構成のグラフエリア</p>
+              </div>
+            </div>
+            <div className={style.subCategoryContentWrap}>
+              <h2 className={style.subCategoryTitle}>人口ピラミッド</h2>
+              <div className={style.subCategoryContent}>
+                <p>人口ピラミッドのグラフエリア</p>
+              </div>
+            </div>
+          </div>
+        </div>
       </Layout>
     </div>
   );

--- a/src/components/uiParts/MenuBar.module.css
+++ b/src/components/uiParts/MenuBar.module.css
@@ -1,7 +1,4 @@
 .menu {
-  position: fixed;
-  left: 0;
-  width: 240px;
   height: 100%;
   overflow: auto;
   border-right: solid #EEEEEE;

--- a/src/components/uiParts/MenuBar.tsx
+++ b/src/components/uiParts/MenuBar.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import styles from "@/components/uiParts/MenuBar.module.css";
 
 export const MenuBar = () => {
@@ -9,7 +10,9 @@ export const MenuBar = () => {
       <nav className={styles.navigations}>
         <ul>
           <li>
-            <a href="#">メニューA</a>
+            <Link href="/population">
+              <a>人口マップ</a>
+            </Link>
           </li>
           <li>
             <a href="#">メニューB</a>


### PR DESCRIPTION
## チケットへのリンク

- https://example.com

## 変更内容

- メインメニューバーに横幅の固定値をCSSで持たせていたが、`Layout`コンポーネント側で幅の調整を行うよう修正
- メインメニューに"人口マップ"を追加
- 人口マップページのマークアップを実装

## 動作確認

- メインメニューの人口マップ押下時に、人口マップのマークアップが正常に表示されること
<img width="1404" alt="スクリーンショット 2022-05-15 18 38 01" src="https://user-images.githubusercontent.com/48116627/168466476-ff9c55e3-68f4-4962-a5c0-cc3a94bf72b0.png">


## その他

- コンポーネント化は別途実装
