### PR TITLE
Feat/グラフエリアのデザイン更新

### DIFF
--- a/src/components/population/Population.module.css
+++ b/src/components/population/Population.module.css
@@ -5,7 +5,7 @@
 }
 
 .searchInputWrap {
-  width: 80%;
+  width: 100%;
   margin-right: auto;
 }
 
@@ -15,17 +15,6 @@
   border: 1px solid #eaeaea;
   border-radius: 18px;
   padding: 1rem;
-}
-
-.searchBtnWrap {
-  width: 15%;
-}
-
-.searchBtn {
-  width: 100%;
-  height: 4.8rem;
-  border: 1px solid #eaeaea;
-  border-radius: 18px;
 }
 
 .mainCategoryContentsArea {

--- a/src/components/population/Population.module.css
+++ b/src/components/population/Population.module.css
@@ -37,11 +37,12 @@
 }
 
 .subCategoryContentsArea {
-  display: flex;
+  margin-left: 1rem;
 }
 
 .subCategoryContentWrap {
-  width: 50%;
+  display: inline-block;
+  width: 100%;
   height: 50rem;
 }
 

--- a/src/components/population/Population.tsx
+++ b/src/components/population/Population.tsx
@@ -227,16 +227,8 @@ const PopulationPage: NextPage = () => {
               className={style.searchInput}
               type="search"
               name="search"
-              placeholder="検索"
+              placeholder="都道府県を選択"
               onClick={openModal}
-            />
-          </div>
-          <div className={style.searchBtnWrap}>
-            <input
-              className={style.searchBtn}
-              type="submit"
-              name="submit"
-              value="検索"
             />
           </div>
         </div>


### PR DESCRIPTION
## チケットへのリンク

- https://example.com

## 変更内容

- グラフ描画エリアを横並びから縦並びに修正
- 検索ボタンが不要なため、削除
- プレスホルダーの文言を「検索」→「都道府県を選択」に更新

## 動作確認

- グラフが縦並びで表示されること
- プレスホルダーが更新されていること
- 検索ボタンが削除されていること
<img width="1317" alt="スクリーンショット 2022-07-03 16 34 04" src="https://user-images.githubusercontent.com/48116627/177030004-9adc2e14-c393-4b73-8138-5a31d290825c.png">



## その他

- レビュワーへの参考情報（実装上の懸念点や注意点、相談などあれば記載）
