### PR TITLE
fix/グラフx軸の重複バグ修正

### DIFF
--- a/src/components/population/Population.tsx
+++ b/src/components/population/Population.tsx
@@ -109,11 +109,16 @@ const PopulationPage: NextPage = () => {
       }
     }
     setTotalPopulation(allTotalPopulationList);
+    console.log("totalPopulationList", totalPopulationList);
     setYoungPopulation(allYoungPopulationList);
     setWorkingAgePopulation(allWorkingAgePopulationList);
     setAgedPopulation(allAgedPopulationList);
   };
 
+  /**
+   * グラフコンポーネントの生成
+   * @see https://recharts.org/en-US/examples/LineChartHasMultiSeries
+   */
   const totalPopulationLineChart = (
     <ResponsiveContainer width="100%" height="100%">
       <LineChart
@@ -132,7 +137,7 @@ const PopulationPage: NextPage = () => {
           />
         ))}
         <CartesianGrid stroke="#ccc" strokeDasharray="5 5" />
-        <XAxis dataKey="year" />
+        <XAxis dataKey="year" allowDuplicatedCategory={false} />
         <YAxis dataKey="value" />
         <Tooltip />
         <Legend />
@@ -158,7 +163,7 @@ const PopulationPage: NextPage = () => {
           />
         ))}
         <CartesianGrid stroke="#ccc" strokeDasharray="5 5" />
-        <XAxis dataKey="year" />
+        <XAxis dataKey="year" allowDuplicatedCategory={false} />
         <YAxis dataKey="value" />
         <Tooltip />
         <Legend />
@@ -184,7 +189,7 @@ const PopulationPage: NextPage = () => {
           />
         ))}
         <CartesianGrid stroke="#ccc" strokeDasharray="5 5" />
-        <XAxis dataKey="year" />
+        <XAxis dataKey="year" allowDuplicatedCategory={false} />
         <YAxis dataKey="value" />
         <Tooltip />
         <Legend />
@@ -210,7 +215,7 @@ const PopulationPage: NextPage = () => {
           />
         ))}
         <CartesianGrid stroke="#ccc" strokeDasharray="5 5" />
-        <XAxis dataKey="year" />
+        <XAxis dataKey="year" allowDuplicatedCategory={false} />
         <YAxis dataKey="value" />
         <Tooltip />
         <Legend />


### PR DESCRIPTION
## チケットへのリンク

- https://example.com

## 変更内容

- グラフ描画時のx軸に同じ値が繰り返し表示されていたため、`XAxis`に`allowDuplicatedCategory`の設定を付与

## 動作確認

- グラフ描画時、x軸に重複した値が表示されないこと
<img width="740" alt="スクリーンショット 2022-07-10 15 34 59" src="https://user-images.githubusercontent.com/48116627/178134108-b2a7ef55-afe7-4156-9405-17e216915c27.png">

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点、相談などあれば記載）
