### PR TITLE
Feat/検索モーダル内のチェック状態判定と検索時モーダル開閉処理の実装

### DIFF
--- a/src/components/population/PopulationSearchModal.tsx
+++ b/src/components/population/PopulationSearchModal.tsx
@@ -55,6 +55,15 @@ const PopulationSearchModal: NextPage<Props> = ({
     }
   };
 
+  /**
+   * 都道府県が選択済みかどうかを判定
+   * @param prefecture 都道府県データ
+   * @returns チェック済みの場合 true、未チェックの場合 falseを返却
+   */
+  const isChecked = (prefecture: Prefecture): boolean => {
+    return checkedPrefectureList.includes(prefecture);
+  };
+
   /** 検索処理を実行 */
   const onSearch = async () => {
     handleSearch(checkedPrefectureList);
@@ -79,6 +88,7 @@ const PopulationSearchModal: NextPage<Props> = ({
                       <input
                         id={String(prefecture.prefCode)}
                         type="checkbox"
+                        checked={isChecked(prefecture)}
                         onChange={() => handleChange(prefecture)}
                       />
                       {prefecture.prefName}

--- a/src/components/population/PopulationSearchModal.tsx
+++ b/src/components/population/PopulationSearchModal.tsx
@@ -64,9 +64,10 @@ const PopulationSearchModal: NextPage<Props> = ({
     return checkedPrefectureList.includes(prefecture);
   };
 
-  /** 検索処理を実行 */
+  /** 検索処理を実行しモーダルを閉じる */
   const onSearch = async () => {
     handleSearch(checkedPrefectureList);
+    closeModal();
   };
 
   return (


### PR DESCRIPTION
## チケットへのリンク

- https://example.com

## 変更内容

- モーダル内の都道府県が選択済みかどうかを判定し、チェックボックスの状態を変更する処理の実装
- 検索ボタン押下時にモーダルを閉じる処理の追加

## 動作確認

- 一度モーダルを閉じてもチェック済みの都道府県が選択状態になっていること
- 検索ボタン押下時にモーダルが閉じること
[![Image from Gyazo](https://i.gyazo.com/c7ccf4ee2934a8c64df8b8b37d53e711.gif)](https://gyazo.com/c7ccf4ee2934a8c64df8b8b37d53e711)

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点、相談などあれば記載）
