### PR TITLE
Refactor/グラフコンポーネント生成のhooks化

### DIFF
--- a/src/components/population/Population.tsx
+++ b/src/components/population/Population.tsx
@@ -13,6 +13,7 @@ import {
 import style from "./Population.module.css";
 import { Layout } from "@/components/layouts/Layout";
 import PopulationSearchModal from "@/components/population/PopulationSearchModal";
+import useGenerateChart from "@/hooks/useGenerateChart";
 
 // TODO api/prefectures/index.tsにも同じ型定義があるためリファクタ
 type Prefecture = {
@@ -55,6 +56,7 @@ const PopulationPage: NextPage = () => {
     ChartData[]
   >([]);
   const [agedPopulationList, setAgedPopulation] = useState<ChartData[]>([]);
+  const { generateLineChart } = useGenerateChart();
 
   const openModal = () => {
     setModalStatus(true);
@@ -115,113 +117,25 @@ const PopulationPage: NextPage = () => {
     setAgedPopulation(allAgedPopulationList);
   };
 
-  /**
-   * グラフコンポーネントの生成
-   * @see https://recharts.org/en-US/examples/LineChartHasMultiSeries
-   */
-  const totalPopulationLineChart = (
-    <ResponsiveContainer width="100%" height="100%">
-      <LineChart
-        width={600}
-        height={300}
-        margin={{ top: 5, right: 20, bottom: 5, left: 0 }}
-      >
-        {totalPopulationList.map((totalPopulation) => (
-          <Line
-            dataKey="value"
-            data={totalPopulation.data}
-            name={totalPopulation.prefectureName}
-            key={totalPopulation.prefectureName}
-            type="monotone"
-            stroke="#8884d8"
-          />
-        ))}
-        <CartesianGrid stroke="#ccc" strokeDasharray="5 5" />
-        <XAxis dataKey="year" allowDuplicatedCategory={false} />
-        <YAxis dataKey="value" />
-        <Tooltip />
-        <Legend />
-      </LineChart>
-    </ResponsiveContainer>
-  );
+  // 総人口グラフ
+  const totalPopulationLineChart = () => {
+    return generateLineChart(totalPopulationList);
+  };
 
-  const youngPopulationLineChart = (
-    <ResponsiveContainer width="100%" height="100%">
-      <LineChart
-        width={600}
-        height={300}
-        margin={{ top: 5, right: 20, bottom: 5, left: 0 }}
-      >
-        {youngPopulationList.map((youngPopulation) => (
-          <Line
-            dataKey="value"
-            data={youngPopulation.data}
-            name={youngPopulation.prefectureName}
-            key={youngPopulation.prefectureName}
-            type="monotone"
-            stroke="#8884d8"
-          />
-        ))}
-        <CartesianGrid stroke="#ccc" strokeDasharray="5 5" />
-        <XAxis dataKey="year" allowDuplicatedCategory={false} />
-        <YAxis dataKey="value" />
-        <Tooltip />
-        <Legend />
-      </LineChart>
-    </ResponsiveContainer>
-  );
+  // 年少人口グラフ
+  const youngPopulationLineChart = () => {
+    return generateLineChart(youngPopulationList);
+  };
 
-  const workingAgePopulationLineChart = (
-    <ResponsiveContainer width="100%" height="100%">
-      <LineChart
-        width={600}
-        height={300}
-        margin={{ top: 5, right: 20, bottom: 5, left: 0 }}
-      >
-        {workingAgePopulationList.map((workingAgePopulation) => (
-          <Line
-            dataKey="value"
-            data={workingAgePopulation.data}
-            name={workingAgePopulation.prefectureName}
-            key={workingAgePopulation.prefectureName}
-            type="monotone"
-            stroke="#8884d8"
-          />
-        ))}
-        <CartesianGrid stroke="#ccc" strokeDasharray="5 5" />
-        <XAxis dataKey="year" allowDuplicatedCategory={false} />
-        <YAxis dataKey="value" />
-        <Tooltip />
-        <Legend />
-      </LineChart>
-    </ResponsiveContainer>
-  );
+  // 生産年齢人口グラフ
+  const workingAgePopulationLineChart = () => {
+    return generateLineChart(workingAgePopulationList);
+  };
 
-  const agedPopulationLineChart = (
-    <ResponsiveContainer width="100%" height="100%">
-      <LineChart
-        width={600}
-        height={300}
-        margin={{ top: 5, right: 20, bottom: 5, left: 0 }}
-      >
-        {agedPopulationList.map((agedPopulation) => (
-          <Line
-            dataKey="value"
-            data={agedPopulation.data}
-            name={agedPopulation.prefectureName}
-            key={agedPopulation.prefectureName}
-            type="monotone"
-            stroke="#8884d8"
-          />
-        ))}
-        <CartesianGrid stroke="#ccc" strokeDasharray="5 5" />
-        <XAxis dataKey="year" allowDuplicatedCategory={false} />
-        <YAxis dataKey="value" />
-        <Tooltip />
-        <Legend />
-      </LineChart>
-    </ResponsiveContainer>
-  );
+  // 老年人口グラフ
+  const agedPopulationLineChart = () => {
+    return generateLineChart(agedPopulationList);
+  };
 
   return (
     <div>
@@ -243,25 +157,25 @@ const PopulationPage: NextPage = () => {
             <div className={style.subCategoryContentWrap}>
               <h2 className={style.subCategoryTitle}>総人口</h2>
               <div className={style.subCategoryContent}>
-                {totalPopulationLineChart}
+                {totalPopulationLineChart()}
               </div>
             </div>
             <div className={style.subCategoryContentWrap}>
               <h2 className={style.subCategoryTitle}>年少人口</h2>
               <div className={style.subCategoryContent}>
-                {youngPopulationLineChart}
+                {youngPopulationLineChart()}
               </div>
             </div>
             <div className={style.subCategoryContentWrap}>
               <h2 className={style.subCategoryTitle}>生産年齢人口</h2>
               <div className={style.subCategoryContent}>
-                {workingAgePopulationLineChart}
+                {workingAgePopulationLineChart()}
               </div>
             </div>
             <div className={style.subCategoryContentWrap}>
               <h2 className={style.subCategoryTitle}>老年人口</h2>
               <div className={style.subCategoryContent}>
-                {agedPopulationLineChart}
+                {agedPopulationLineChart()}
               </div>
             </div>
           </div>

--- a/src/components/population/Population.tsx
+++ b/src/components/population/Population.tsx
@@ -111,7 +111,6 @@ const PopulationPage: NextPage = () => {
       }
     }
     setTotalPopulation(allTotalPopulationList);
-    console.log("totalPopulationList", totalPopulationList);
     setYoungPopulation(allYoungPopulationList);
     setWorkingAgePopulation(allWorkingAgePopulationList);
     setAgedPopulation(allAgedPopulationList);

--- a/src/hooks/useGenerateChart.tsx
+++ b/src/hooks/useGenerateChart.tsx
@@ -1,0 +1,66 @@
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+} from "recharts";
+
+type UseGenerateChart = {
+  generateLineChart: (chartDataList: ChartData[]) => JSX.Element;
+};
+
+// TODO src/components/population/Population.tsxにも同じ型定義があるためリファクタ
+type Composition = {
+  label?: string;
+  year: number;
+  value: number;
+};
+
+type ChartData = {
+  prefectureName: string;
+  data: Composition[];
+};
+
+/**
+ * RechartsのLineChartを生成するhooks
+ */
+const useGenerateChart = (): UseGenerateChart => {
+  /**
+   * LineChartグラフコンポーネントの生成
+   * @param chartDataList グラフコンポーネントに必要なチャートデータ
+   * @returns LineChartコンポーネント
+   * @see https://recharts.org/en-US/examples/LineChartHasMultiSeries
+   */
+  const generateLineChart = (chartDataList: ChartData[]) => (
+    <ResponsiveContainer width="100%" height="100%">
+      <LineChart
+        width={600}
+        height={300}
+        margin={{ top: 5, right: 20, bottom: 5, left: 0 }}
+      >
+        {chartDataList.map((chartData) => (
+          <Line
+            dataKey="value"
+            data={chartData.data}
+            name={chartData.prefectureName}
+            key={chartData.prefectureName}
+            type="monotone"
+            stroke="#8884d8"
+          />
+        ))}
+        <CartesianGrid stroke="#ccc" strokeDasharray="5 5" />
+        <XAxis dataKey="year" allowDuplicatedCategory={false} />
+        <YAxis dataKey="value" />
+        <Tooltip />
+        <Legend />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+
+  return { generateLineChart };
+};
+export default useGenerateChart;


### PR DESCRIPTION
## チケットへのリンク

- https://example.com

## 変更内容

- `LineChart`グラフを生成する処理が、複数箇所で実装されていたため、コンポーネント生成処理を行うカスタムhooksを作成し、データを渡すのみにリファクタリング
- 不要なコンソールログ出力処理を削除

## 動作確認

- 修正前とグラフ描画に違いが発生していないこと

## その他

- [React Design Patterns: Return Component From Hooks](https://blog.bitsrc.io/new-react-design-pattern-return-component-from-hooks-79215c3eac00)
- [【LINE証券 FrontEnd】コンポーネントをカスタムフックで提供してみた](https://engineering.linecorp.com/ja/blog/line-securities-frontend-3/)
- [react-hooks-use-modal](https://github.com/microcmsio/react-hooks-use-modal)
